### PR TITLE
There was a bug when using the existing create ticket code for RT 4.0.1,

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,11 +98,12 @@ Create ticket
 ::
 
  message = 'My useless\ntext on\nthree lines.'
- content = {
-     'Queue': 1,#'', 2
-     'Subject' : 'New Ticket',
-     'Text' : message.replace('\n', '\n '),
- }
+ content = {'content': {
+						 'Queue': 1,#'', 2
+						 'Subject' : 'New Ticket',
+						 'Text' : message.replace('\n', '\n '),
+						}
+			}
  try:
      response = resource.post(path='ticket/new', payload=content,)
      logger.info(response.parsed)


### PR DESCRIPTION
The work around for this is to change the payload so that the root attribute for the post
request is content, which contains a dictionary of the ticket attributes.

If you don't do this on my version of RT the output looks like:
[DEBUG] POST ticket/new
[DEBUG] {'Content-Length': '459', 'Content-Type': 'multipart/form-data; boundary=xXXxXXyYYzzz', 'Accept': 'text/plain'}
[DEBUG] '--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="Queue"\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 1\r\n\r\n1\r\n--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="Text"\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 47\r\n\r\nMy%20useless%0A%20text%20on%0A%20three%20lines.\r\n--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="Subject"\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 12\r\n\r\nNew%20Ticket\r\n--xXXxXXyYYzzz--\r\n'
[INFO] POST
[INFO] http://<my host>/REST/1.0/ticket/new
[DEBUG] HTTP_STATUS: 200 OK
[DEBUG] 'RT/4.0.1 200 Ok\n\n# Required: id, Queue\n\nid: ticket/new\nQueue: \nRequestor: APIUser\nSubject: \nCc:\nAdminCc:\nOwner: \nStatus: new\nPriority: \nInitialPriority: \nFinalPriority: \nTimeEstimated: 0\nStarts: 2012-01-19 11:56:59\nDue: 2012-01-19 11:56:59\nText: \n\n'
[DEBUG] RESOURCE_STATUS: 200 Ok
[INFO] [[('id', 'ticket/new'), ('Queue', ''), ('Requestor', 'APIUser'), ('Subject', ''), ('Cc', ''), ('AdminCc', ''), ('Owner', ''), ('Status', 'new'), ('Priority', ''), ('InitialPriority', ''), ('FinalPriority', ''), ('TimeEstimated', '0'), ('Starts', '2012-01-19 11:56:59'), ('Due', '2012-01-19 11:56:59'), ('Text', '')]]
[INFO] [[('id', 'ticket/new'), ('Queue', ''), ('Requestor', 'APIUser'), ('Subject', ''), ('Cc', ''), ('AdminCc', ''), ('Owner', ''), ('Status', 'new'), ('Priority', ''), ('InitialPriority', ''), ('FinalPriority', ''), ('TimeEstimated', '0'), ('Starts', '2012-01-19 11:56:59'), ('Due', '2012-01-19 11:56:59'), ('Text', '')]]

Signed-off-by: Jason Marshall ctrlspc@gmail.com
