### PR TITLE
Support for multiline text in comment

### DIFF
--- a/rtkit/forms.py
+++ b/rtkit/forms.py
@@ -130,6 +130,11 @@ class BoundaryItem(object):
 
 
 def encode(value, headers):
+    if 'Text' in value['content']:
+        # If a comment contains multiple lines, each new line must be preceded
+        # by a space (e.g. "line 1\n line 2").
+        if isinstance(value['content']['Text'], basestring):
+            value['content']['Text'] = "\n ".join(value['content']['Text'].split('\n'))
     if len(value) == 1 and 'content' in value:
         value = 'content={0}'.format(_content_encode(value['content']))
         headers.setdefault('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')


### PR DESCRIPTION
From official RT wiki [1] about REST interface: "If your comment contains multiple lines, each new line must be preceded by a space (e.g. "line 1\n line 2")." 

This patch introduce logic which do the thing. In case that the 'Text' field in an user request contains multiline string, a space is prepended to every line (except the first line).

Usage of the library remains the same:
params = {
    'content' :{
        'Action' : 'comment',
        'Text' : 'Comment\nwith\nseveral\nlines',
    },
}
response = resource.post(path='ticket/16/comment', payload=params,)

Benefit:
User can add comments with multiple lines without need of own text pre-processing (adding a space before each line of text).

[1] http://requesttracker.wikia.com/wiki/REST
