### PR TITLE
Python 3.x Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ENV
 venv
 .cache
 docs/_build/
+build/

--- a/rtkit/authenticators.py
+++ b/rtkit/authenticators.py
@@ -14,10 +14,23 @@
 
 """
 import os
-import urllib
-import urllib2
-import cookielib
-from urlparse import urlsplit, parse_qs, urlunsplit
+# for compatibility with Python 3.x
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+try:
+    import urllib.request as urllib2
+except ImportError:
+    import urllib2
+try:
+    import http.cookiejar as cookielib
+except ImportError:
+    import cookielib
+try:
+    from urllib.parse import urlsplit, parse_qs, urlunsplit
+except ImportError:
+    from urlparse import urlsplit, parse_qs, urlunsplit
 
 __all__ = [
     'BasicAuthenticator',
@@ -111,7 +124,7 @@ class CookieAuthenticator(AbstractAuthenticator):
     def _login(self):
         data = {'user': self.username, 'pass': self.password}
         self.opener.open(
-            urllib2.Request(self.url, urllib.urlencode(data))
+            urllib2.Request(self.url, urlencode(data))
         )
 
 
@@ -148,7 +161,7 @@ class QueryStringAuthHandler(urllib2.BaseHandler):
         query_params['pass'] = self.password
 
         request = urllib2.Request(
-            url=urlunsplit((scheme, netloc, path, urllib.urlencode(query_params, doseq=True), fragment)),
+            url=urlunsplit((scheme, netloc, path, urlencode(query_params, doseq=True), fragment)),
             data=request.data,
             headers=request.headers
         )

--- a/rtkit/comment.py
+++ b/rtkit/comment.py
@@ -1,5 +1,5 @@
 import re
-from errors import *
+from .errors import *
 
 UNKNOWN_PATTERN = '# Unknown object type: (?P<t>.+)'
 UNKNOWN = re.compile(UNKNOWN_PATTERN)

--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -1,4 +1,8 @@
-from itertools import ifilterfalse
+# for compatibility with Python 3.x
+try:
+    from itertools import filterfalse as ifilterfalse
+except ImportError:
+    from itertools import ifilterfalse
 import re
 from rtkit import comment
 
@@ -6,10 +10,10 @@ from rtkit import comment
 class RTParser(object):
     """ RFC5322 Parser - see https://tools.ietf.org/html/rfc5322"""
 
-    HEADER = re.compile(r'^RT/(?P<v>.+)\s+(?P<s>(?P<i>\d+).+)')
-    COMMENT = re.compile(r'^#\s+.+$')
-    SYNTAX_COMMENT = re.compile(r'^>>\s+.+$')
-    SECTION = re.compile(r'^--', re.M | re.U)
+    HEADER = re.compile(b'^RT/(?P<v>.+)\s+(?P<s>(?P<i>\d+).+)')
+    COMMENT = re.compile(b'^#\s+.+$')
+    SYNTAX_COMMENT = re.compile(b'^>>\s+.+$')
+    SECTION = re.compile(b'^--', re.M | re.U)
 
     @classmethod
     def parse(cls, body, decoder):

--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -10,10 +10,10 @@ from rtkit import comment
 class RTParser(object):
     """ RFC5322 Parser - see https://tools.ietf.org/html/rfc5322"""
 
-    HEADER = re.compile(b'^RT/(?P<v>.+)\s+(?P<s>(?P<i>\d+).+)')
-    COMMENT = re.compile(b'^#\s+.+$')
-    SYNTAX_COMMENT = re.compile(b'^>>\s+.+$')
-    SECTION = re.compile(b'^--', re.M | re.U)
+    HEADER = re.compile(r'^RT/(?P<v>.+)\s+(?P<s>(?P<i>\d+).+)')
+    COMMENT = re.compile(r'^#\s+.+$')
+    SYNTAX_COMMENT = re.compile(r'^>>\s+.+$')
+    SECTION = re.compile(r'^--', re.M | re.U)
 
     @classmethod
     def parse(cls, body, decoder):
@@ -66,7 +66,7 @@ class RTParser(object):
         """
         try:
             lines = ifilterfalse(cls.COMMENT.match, lines)
-            return [(k, v.strip(' ')) for k, v in [l.split(':', 1) for l in lines]]
+            return [(k.encode('utf-8'), v.strip(' ').encode('utf-8')) for k, v in [l.split(':', 1) for l in lines]]
         except (ValueError, IndexError):
             return []
 
@@ -84,7 +84,7 @@ class RTParser(object):
         flines = filter(cls.COMMENT.match, lines)
         if len(flines) == 1 and flines[0] == '# Syntax error.':
             flines = [l.strip('>> ') for l in filter(cls.SYNTAX_COMMENT.match, lines)]
-        return [(k.strip('# '), v.strip(' ')) for k, v in [l.split(':', 1) for l in flines]]
+        return [(k.strip('# ').encode('utf-8'), v.strip(' ').encode('utf-8')) for k, v in [l.split(':', 1) for l in flines]]
 
     @classmethod
     def build(cls, body):
@@ -121,4 +121,4 @@ class RTParser(object):
                 else:
                     logic_lines.append(line)
             return logic_lines
-        return [build_section(b) for b in cls.SECTION.split(body)]
+        return [build_section(b) for b in cls.SECTION.split(body.decode('utf-8'))]

--- a/rtkit/resource.py
+++ b/rtkit/resource.py
@@ -1,7 +1,11 @@
 import logging
 import re
 import os
-from urllib2 import Request, HTTPError
+try:
+    from urllib.request import Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import Request, HTTPError
 from rtkit import forms, errors
 from rtkit.parser import RTParser
 

--- a/rtkit/resource.py
+++ b/rtkit/resource.py
@@ -89,9 +89,9 @@ class RTResponse(object):
         self.logger.info(request.get_method())
         self.logger.info(request.get_full_url())
         self.logger.debug('HTTP_STATUS: {0}'.format(self.status))
-        r = RTParser.HEADER.match(self.body)
+        r = RTParser.HEADER.match(self.body.decode('utf-8'))
         if r:
-            self.status = r.group('s')
+            self.status = r.group('s').encode('utf-8')
             self.status_int = int(r.group('i'))
         else:
             self.logger.error('"{0}" is not valid'.format(self.body))

--- a/rtkit/tracker.py
+++ b/rtkit/tracker.py
@@ -1,5 +1,9 @@
 import urllib
-import urllib2
+# For compatibility with python 3.x
+try:
+    from urllib.request import Request
+except ImportError:
+    from urllib2 import Request
 from rtkit.resource import RTResource
 from rtkit.entities import *
 
@@ -30,7 +34,7 @@ class Tracker(RTResource):
         content = {'query': query, 'format': 'l'}
         if order:
             content['orderby'] = order
-        req = urllib2.Request(
+        req = Request(
             url=self.auth.url + 'search/ticket',
             data=urllib.urlencode(content),
         )


### PR DESCRIPTION
Most of the changes is just fixing the new import paths in python 3.x and some unicode stuff with regex.

I tried not to break backwards compatibility, so all strings returned are still byte strings (also in python 3). 

It seems, there is no kerberos_urllib2 for python 3.x, the other authenticators should be working. I tested the QueryStringAuthenticator and could read a ticket with python 3.4 and 2.7