### PR TITLE
Fix attachment request if content type is application/octet-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 before_script:
-  - pip install -U -r test_requirements.txt --use-mirrors
+  - pip install -U -r test_requirements.txt
 script:
   - py.test --doctest-modules --pep8 rtkit -v --cov rtkit --cov-report term-missing
 after_success:
-  - pip install python-coveralls --use-mirrors
+  - pip install python-coveralls
   - coveralls

--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -121,4 +121,4 @@ class RTParser(object):
                 else:
                     logic_lines.append(line)
             return logic_lines
-        return [build_section(b) for b in cls.SECTION.split(body.decode('utf-8'))]
+        return [build_section(b) for b in cls.SECTION.split(body.decode('utf-8', 'ignore'))]

--- a/rtkit/resource.py
+++ b/rtkit/resource.py
@@ -89,7 +89,7 @@ class RTResponse(object):
         self.logger.info(request.get_method())
         self.logger.info(request.get_full_url())
         self.logger.debug('HTTP_STATUS: {0}'.format(self.status))
-        r = RTParser.HEADER.match(self.body.decode('utf-8'))
+        r = RTParser.HEADER.match(self.body.decode('utf-8', 'ignore'))
         if r:
             self.status = r.group('s').encode('utf-8')
             self.status_int = int(r.group('i'))


### PR DESCRIPTION
When fetching binary attachments from RT with a returned content-type of application/octet-stream; trying to decode the body as utf-8 does not work and throws an exception.

The following is a simple fix to just ignore any decoding issues and fixes the issue.

Any chance you could merge this please?