### PR TITLE
Fix vertical tab handling in parser.

### DIFF
--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -1,7 +1,9 @@
 try:
     from itertools import filterfalse as ifilterfalse
+    from cStringIO import StringIO
 except ImportError:
     from itertools import ifilterfalse
+    from io import StringIO
 import re
 from rtkit import comment
 
@@ -112,8 +114,11 @@ class RTParser(object):
         """
         def build_section(section):
             logic_lines = []
-            for line in filter(None, section.splitlines()):
-                if cls.HEADER.match(line):
+            for line in StringIO(section):
+                # strip trailing newline
+                if line and line[-1] == '\n':
+                    line = line.rstrip('\n')
+                if not line or cls.HEADER.match(line):
                     continue
                 if line[0].isspace():
                     logic_lines[-1] += '\n' + line.strip(' ')

--- a/rtkit/tests/parser.py
+++ b/rtkit/tests/parser.py
@@ -29,3 +29,12 @@ Subject: Test Vulnerability for Script Dev
 '''
         parsed = RTParser.parse(body, RTParser.decode_comment)
         self.assertEqual(parsed, [[('queue', 'You may not create requests in that queue.')]])
+
+    def test_vertical_tab(self):
+        body = '''RT/3.8.7 200 Ok
+Field: first line
+       second\vline
+       third line
+'''
+        parsed = RTParser.parse(body, RTParser.decode)
+        self.assertEqual(parsed, [[('Field', 'first line\nsecond\x0bline\nthird line')]])


### PR DESCRIPTION
Python's string.splitlines() also splits on vertical tabs, which
can be used as content in tickets.

Resolves #52