### PR TITLE
Replace urllib2_kerberos with urllib_gssapi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,8 @@ QueryString Authentication
 
     resource = RTResource('http://<HOST>/REST/1.0/', '<USER>', '<PWD>', QueryStringAuthenticator)
 
-Kerberos Authentication
----------------------------
+GSSAPI/Kerberos Authentication
+------------------------------
 
 ::
 
@@ -138,7 +138,7 @@ Kerberos Authentication
 
     resource = RTResource(url, None, None, KerberosAuthenticator)
 
-.. warning:: Remeber to install `urllib2_kerberos`.
+.. warning:: Remeber to install `urllib_gssapi`.
 
 .. _overview:
 

--- a/rtkit/authenticators.py
+++ b/rtkit/authenticators.py
@@ -170,13 +170,13 @@ class QueryStringAuthHandler(urllib2.BaseHandler):
 
 
 class KerberosAuthenticator(AbstractAuthenticator):
-    """Authenticate using Kerberos
+    """Authenticate using GSSAPI/Kerberos
 
     .. warning::
 
-        * Requires the urllib2_kerberos
-        * http://pypi.python.org/pypi/urllib2_kerberos/
-        * sudo easy_install urllib2_kerberos
+        * Requires urllib_gssapi
+        * https://pypi.python.org/pypi/urllib_gssapi
+        * sudo pip install urllib_gssapi
 
     .. doctest::
 
@@ -193,11 +193,11 @@ class KerberosAuthenticator(AbstractAuthenticator):
     """
     def __init__(self, username, password, url):
         try:
-            from urllib2_kerberos import HTTPKerberosAuthHandler
+            from urllib_gssapi import HTTPSPNEGOAuthHandler
         except ImportError:
-            raise ImportError('You need urllib2_kerberos, try: pip install urllib2_kerberos')
+            raise ImportError('You need urllib_gssapi, try: pip install urllib2_kerberos')
 
         super(KerberosAuthenticator, self).__init__(
             username, password, url,
-            HTTPKerberosAuthHandler()
+            HTTPSPNEGOAuthHandler()
         )


### PR DESCRIPTION
This allows all available GSSAPI mechanisms to be used in
authentication, not just Kerberos.  urllib_gssapi is based on the more
powerful python-gssapi instead of python-kerberos.  python-kerberos is
slated for removal from Fedora.

(In an ideal world, we'd also rename the exported class from "KerberosAuthenticator" to "GSSAPIAuthenticator" or "SPNEGOAuthenticator", but I don't know how feasible that is.  It'd also be easy to have a new name shim an old one.)

(Information on python-kerberos deprecation can be found [here](https://fedoraproject.org/wiki/Changes/kerberos-in-python-modernization), but ignore the deadline; I'm behind where I'd hoped to be.)