### PR TITLE
Decouple imports to fix error in python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements.txt
 before_script:

--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -1,9 +1,11 @@
 try:
     from itertools import filterfalse as ifilterfalse
-    from cStringIO import StringIO
 except ImportError:
     from itertools import ifilterfalse
+try:
     from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
 import re
 from rtkit import comment
 


### PR DESCRIPTION
In python3 both the try case and the except case fails:
- io must be used instead of cStringIO
- filterfalse must be used instead of ifilterfalse
By decoupling these imports into separate try-excepts, this gets more
robust and should work in more cases. Also make io the default as it
should work for all python >=2.6.