### PR TITLE
Fix import on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements.txt
 before_script:

--- a/rtkit/__init__.py
+++ b/rtkit/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Andrea De Marco <24erre@gmail.com>'
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 __classifiers__ = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
@@ -11,7 +11,7 @@ __classifiers__ = [
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Software Development :: Libraries',
 ]
-__copyright__ = "2011 - 2017, %s " % __author__
+__copyright__ = "2011 - 2019, %s " % __author__
 __license__ = """
    Copyright (C) %s
 

--- a/rtkit/parser.py
+++ b/rtkit/parser.py
@@ -1,9 +1,11 @@
 try:
-    from itertools import filterfalse as ifilterfalse
     from cStringIO import StringIO
 except ImportError:
-    from itertools import ifilterfalse
     from io import StringIO
+try:
+    from itertools import ifilterfalse
+except ImportError:
+    from itertools import filterfalse as ifilterfalse
 import re
 from rtkit import comment
 


### PR DESCRIPTION
This changes fixes the import for cStringIO and ifilterfalse as intended
by pull request #60. In this old pull request the import for
ifilterfalse is tried in the wrong direction for Python 2 and 3.